### PR TITLE
Use HF_TOKEN stored in Modal's Secrets instead of local env.

### DIFF
--- a/comfyui.py
+++ b/comfyui.py
@@ -115,7 +115,10 @@ image = (
 )
 
 # download models
-image = image.env({"HF_HUB_ENABLE_HF_TRANSFER": "1"}).run_function(
+image = image.env({
+    "HF_HUB_ENABLE_HF_TRANSFER": "1",
+    "HF_XET_HIGH_PERFORMANCE": "1"
+}).run_function(
     download_all, 
     volumes={"/cache": vol}, 
     secrets=[modal.Secret.from_name("huggingface-secret")

--- a/comfyui.py
+++ b/comfyui.py
@@ -116,7 +116,9 @@ image = (
 
 # download models
 image = image.env({"HF_HUB_ENABLE_HF_TRANSFER": "1"}).run_function(
-    download_all, volumes={"/cache": vol}
+    download_all, 
+    volumes={"/cache": vol}, 
+    secrets=[modal.Secret.from_name("huggingface-secret")
 )
 
 

--- a/comfyui.py
+++ b/comfyui.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -114,15 +115,27 @@ image = (
     .run_commands("git lfs install")
 )
 
+def _hf_secrets() -> list[modal.Secret]:
+    """Prefer Modal Secret 'huggingface-secret'; fall back to local HF_TOKEN
+    env. Public models work even when both are absent (warned)."""
+    try:
+        s = modal.Secret.from_name("huggingface-secret")
+        s.hydrate()  # from_name is lazy, force the existence check here
+        return [s]
+    except modal.exception.NotFoundError:
+        token = os.environ.get("HF_TOKEN", "")
+        if not token:
+            print(
+                "Warning: no Modal Secret 'huggingface-secret' and no HF_TOKEN env. "
+                "Public models will download with throttled bandwidth; "
+                "gated models will fail."
+            )
+        return [modal.Secret.from_dict({"HF_TOKEN": token})]
+
 # download models
-image = image.env({
-    "HF_HUB_ENABLE_HF_TRANSFER": "1",
-    "HF_XET_HIGH_PERFORMANCE": "1"
-}).run_function(
-    download_all, 
-    volumes={"/cache": vol}, 
-    secrets=[modal.Secret.from_name("huggingface-secret")
-)
+image = image.env(
+    {"HF_HUB_ENABLE_HF_TRANSFER": "1", "HF_XET_HIGH_PERFORMANCE": "1"}
+).run_function(download_all, volumes={"/cache": vol}, secrets=_hf_secrets())
 
 
 # setup custom nodes


### PR DESCRIPTION
Currently `modal deploy comfyui.py` will search for HF_TOKEN in local environment, thus getting a warning regarding throttled bandwidth when downloading from huggingface if HF_TOKEN doesn't exists in local environment.

This PR will use the `HF_TOKEN` stored in Modal's Secrets during `download_all`, using the default name (`huggingface-secret`) created by Modal when  creating/adding Huggingface Secret.

Btw, we may want to export `HF_XET_HIGH_PERFORMANCE=1` too, besides `HF_HUB_ENABLE_HF_TRANSFER=1` to get the best download speed 🤔 in favor of `hf_xet` which is the newer and more recommended standard over `hf_transfer`.