### PR TITLE
Create a CPU-only function too

### DIFF
--- a/comfyui.py
+++ b/comfyui.py
@@ -151,3 +151,16 @@ def ui():
     _ = subprocess.Popen(
         "comfy launch --background -- --listen 0.0.0.0 --port 8000", shell=True
     )
+
+@app.function(
+    max_containers=1,
+    volumes={"/cache": vol},
+    scaledown_window=60,  # idle 1 minutes to shutdown
+    enable_memory_snapshot=True,
+)
+@modal.concurrent(max_inputs=10)
+@modal.web_server(8001, startup_timeout=60)
+def ui_cpu():
+    _ = subprocess.Popen(
+        "comfy launch --background -- --listen 0.0.0.0 --port 8001 --cpu", shell=True
+    )


### PR DESCRIPTION
Which can be useful/cheaper for creating/editing workflows, without running a workflow, thus doesn't waste GPU time.

Hopefully there is a way to trigger the GPU function when running a workflow on the CPU-only ComfyUI (i'm still looking for a way to do this 🤔 may be using https://github.com/robertvoy/ComfyUI-Distributed which a bit complicated). But i prefer to do this behind the scene without changing anything in the workflow, may be using a workflow API like https://github.com/kning/modal-comfy-worker only for the inference 🤔  (ie. when clicking the Run/Cancel button in ComfyUI, not sure whether we can redirect running/stopping workflow API request to the GPU instance using MITM/Proxy or not, otherwise may need to modify the UI/frontend).

Probably need to point the base directory (ie. `--base-directory /cache/comfy/ComfyUI`) or at least the user directory (ie. `--user-directory /cache/comfy/ComfyUI`) to the same location in mounted volume, so created/edited workflows can be shared by both (GPU & CPU functions) ComfyUI. 

PS: Base directory handles models, user, input, output, temp, and custom_nodes directories according to `comfy launch -- --help`:
```
--base-directory BASE_DIRECTORY
                        Set the ComfyUI base directory for models,
                        custom_nodes, input, output, temp, and user
                        directories.
--extra-model-paths-config PATH [PATH ...]
                        Load one or more extra_model_paths.yaml files.
 ```
However, if i set the base directory to "/cache/comfy/ComfyUI", and tried to install a custom node from Manager, the custom nodes installation seems to stuck (i haven't figured it out why 🤔 might be manager's security level issue due to listening on IP 0.0.0.0). Saving a workflow to the default (`user/default/workflows`) directory seems to get error 405 (might be due to reverse proxy), similar to this issue https://github.com/modal-labs/modal-examples/issues/1475