### PR TITLE
Support external custom nodes using git

### DIFF
--- a/comfyui.py
+++ b/comfyui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -8,6 +9,11 @@ import modal
 
 from models import models, models_ext
 from plugins import comfy_plugins
+
+try:
+    from plugins import comfy_plugins_ext
+except ImportError:
+    comfy_plugins_ext = []
 
 root_dir = Path(__file__).parent
 
@@ -152,6 +158,54 @@ else:
 
 if comfy_plugins:
     image = image.run_commands("comfy node install " + " ".join(comfy_plugins))
+
+
+def install_ext_plugin(image: modal.Image, plugin: dict) -> modal.Image:
+    """Install one external custom node from git into ComfyUI's custom_nodes.
+
+    Supports optional ``branch``, ``requirements`` (a list of requirement
+    files), an ``install`` script (.py), and ``ext_deps`` (a list of extra pip
+    packages). User-supplied values are shell-quoted before use.
+    """
+    nodes_dir = "/root/comfy/ComfyUI/custom_nodes"
+    url = plugin["url"]
+    name = url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+    work_dir = f"{nodes_dir}/{shlex.quote(name)}"
+
+    branch = plugin.get("branch", "").strip()
+    branch_opt = f"--branch {shlex.quote(branch)} " if branch else ""
+    image = image.run_commands(
+        f"cd {nodes_dir} && git clone --recurse-submodules --single-branch "
+        f"{branch_opt}{shlex.quote(url)}"
+    )
+
+    requirements = plugin.get("requirements") or []
+    if requirements:
+        files = " ".join(f"-r {shlex.quote(f)}" for f in requirements)
+        # --no-deps so a node's requirements can't pull a CPU-only torch over
+        # the CUDA build; use "ext_deps" below to add back what's needed.
+        image = image.run_commands(
+            f"cd {work_dir} && uv pip install --no-deps "
+            f"--python $(command -v python) --compile-bytecode {files}"
+        )
+
+    install = plugin.get("install", "").strip()
+    if install:
+        if install.endswith(".py"):
+            image = image.run_commands(f"cd {work_dir} && python {shlex.quote(install)}")
+        else:
+            print(f"Unsupported installation script: {install}")
+
+    ext_deps = plugin.get("ext_deps") or []
+    if ext_deps:
+        image = image.uv_pip_install(ext_deps, extra_options="--no-deps")
+
+    return image
+
+
+if comfy_plugins_ext:
+    for plugin in comfy_plugins_ext:
+        image = install_ext_plugin(image, plugin)
 
 
 def wait_for_port(port: int, timeout: int = 60):

--- a/comfyui.py
+++ b/comfyui.py
@@ -207,6 +207,14 @@ if comfy_plugins_ext:
     for plugin in comfy_plugins_ext:
         image = install_ext_plugin(image, plugin)
 
+# Bake in the reverse-proxy fix so workflow save works behind Modal's edge
+# proxy, independent of user plugin config (see vendor_nodes/reverse_proxy_fix).
+image = image.add_local_dir(
+    root_dir / "vendor_nodes" / "reverse_proxy_fix",
+    "/root/comfy/ComfyUI/custom_nodes/reverse_proxy_fix",
+    copy=True,
+)
+
 
 def wait_for_port(port: int, timeout: int = 60):
     """Block until the port is accepting connections."""

--- a/plugins.example.py
+++ b/plugins.example.py
@@ -2,3 +2,14 @@ comfy_plugins = [
     # put comfyui custom node id here
     # IMPORTANT: node id from comfyui registry (Not node name)
 ]
+
+comfy_plugins_ext = [
+    # External custom nodes installed directly from git.
+    # {
+    #     "url": "https://github.com/owner/repo.git",
+    #     "branch": "main",  # optional; omit to use the repo's default branch
+    #     "requirements": ["requirements.txt", "pyproject.toml"],  # optional req files
+    #     "install": "install.py",  # optional install script (.py)
+    #     "ext_deps": ["numpy<2", "setuptools<=81"],  # optional extra pip packages
+    # },
+]

--- a/vendor_nodes/reverse_proxy_fix/__init__.py
+++ b/vendor_nodes/reverse_proxy_fix/__init__.py
@@ -1,0 +1,47 @@
+"""Let ComfyUI save workflows when Modal's proxy decodes %2F in userdata paths.
+
+ComfyUI registers POST/DELETE ``/userdata/{file}`` for a single path segment,
+and its frontend percent-encodes the slash so ``workflows/foo.json`` travels as
+``workflows%2Ffoo.json``. Modal's edge proxy decodes that ``%2F`` back to ``/``
+before ComfyUI sees it, so the path gains a segment, the single-segment routes
+stop matching, and saving fails with HTTP 405.
+
+Fix: after ComfyUI registers its routes, register the same userdata handlers
+under a slash-tolerant ``{file:.+}`` pattern so the decoded paths resolve to
+them. ComfyUI's handlers validate the path (``abspath`` + ``commonpath``), so a
+captured value containing ``/`` still cannot escape the user directory.
+"""
+
+from server import PromptServer
+
+_SUFFIX = "/userdata/{file}"
+_METHODS = ("POST", "DELETE")
+
+
+def _register_slash_tolerant_userdata(app):
+    additions = []
+    for route in app.router.routes():
+        resource = route.resource
+        if resource is None or route.method not in _METHODS:
+            continue
+        canonical = resource.canonical  # "/userdata/{file}" or "/api/userdata/{file}"
+        if canonical.endswith(_SUFFIX):
+            tolerant = canonical[: -len("{file}")] + "{file:.+}"
+            additions.append((route.method, tolerant, route.handler))
+    for method, path, handler in additions:
+        app.router.add_route(method, path, handler)
+
+
+_original_add_routes = PromptServer.add_routes
+
+
+def _add_routes(self):
+    result = _original_add_routes(self)
+    _register_slash_tolerant_userdata(self.app)
+    return result
+
+
+PromptServer.add_routes = _add_routes
+
+NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}


### PR DESCRIPTION
With this, users can try new models that are not natively supported by ComfyUI yet (which usually need custom nodes not available in Manager yet). 
I also recently found out that "comfyui_nvidia_rtx_nodes" custom node can't be installed successfully through `comfy node install` for some unknown reason 🤔 so installing it using git can mitigate that issue too.

Added ComfyUI-Reverse-Proxy-Fix custom node to plugins.example.py that can be used to mitigate Error 405 issue when saving a workflow https://github.com/caru-ini/modal-comfyui/issues/4