### PR TITLE
fix(nginx): preserve encoded workflow userdata paths

### DIFF
--- a/comfyui.py
+++ b/comfyui.py
@@ -109,10 +109,11 @@ vol = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
 image = (
     modal.Image.debian_slim(python_version="3.11")
     .add_local_python_source("models", "plugins", copy=True)
-    .apt_install("git", "git-lfs", "libgl1-mesa-dev", "libglib2.0-0", "aria2")
+    .apt_install("git", "git-lfs", "libgl1-mesa-dev", "libglib2.0-0", "aria2", "nginx")
     .pip_install_from_requirements(str(root_dir / "requirements_comfy.txt"))
     .run_commands("comfy --skip-prompt install --nvidia")
     .run_commands("git lfs install")
+    .add_local_file(str(root_dir / "nginx.conf"), "/root/nginx.conf", copy=True)
 )
 
 def _hf_secrets() -> list[modal.Secret]:
@@ -183,18 +184,19 @@ class ComfyUI:
     @modal.enter(snap=True)
     def start_checkpoint(self):
         self.proc = subprocess.Popen(
-            "comfy launch --background -- --listen 0.0.0.0 --port 8000", shell=True
+            "comfy launch --background -- --listen 127.0.0.1 --port 8188", shell=True
         )
         # Block here — snapshot is taken only after this returns
-        wait_for_port(8000, timeout=300)
+        wait_for_port(8188, timeout=300)
 
     @modal.enter(snap=False)
     def start_restore(self):
-        wait_for_port(8000, timeout=30)
+        wait_for_port(8188, timeout=30)
         print("App Restored!")
     
     @modal.web_server(8000, startup_timeout=300)
     def ui(self):
+        subprocess.Popen(["nginx", "-c", "/root/nginx.conf", "-g", "daemon off;"])
         print("App Ready!")
     
     @modal.exit()

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,59 @@
+worker_processes 1;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    access_log /dev/stderr;
+
+    client_max_body_size 100m;
+
+    client_body_temp_path /tmp/nginx_client_body;
+    proxy_temp_path /tmp/nginx_proxy;
+    fastcgi_temp_path /tmp/nginx_fastcgi;
+    uwsgi_temp_path /tmp/nginx_uwsgi;
+    scgi_temp_path /tmp/nginx_scgi;
+
+    upstream comfyui {
+        server 127.0.0.1:8188;
+        keepalive 32;
+    }
+
+    server {
+        listen 8000;
+        server_name _;
+
+        location /ws {
+            proxy_pass http://comfyui;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+        }
+
+        # ComfyUI expects workflow userdata paths as one encoded path segment.
+        # Modal may decode %2F before nginx sees the request, so re-encode the
+        # workflow separator before proxying writes to ComfyUI.
+        location ~ ^/api/userdata/workflows/(.+)$ {
+            proxy_pass http://comfyui/api/userdata/workflows%2F$1$is_args$args;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+
+        location / {
+            proxy_pass http://comfyui;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fix ComfyUI workflow read/write 405 by re-encoding decoded workflow userdata paths in nginx before proxying to ComfyUI.

## Root Cause
ComfyUI expects workflow userdata requests like:
`/api/userdata/workflows%2Fname.json`

In the Modal/nginx path, `%2F` can arrive at nginx as `/`, so ComfyUI receives:
`/api/userdata/workflows/name.json`

That path falls through to a static GET/HEAD-only route, causing POST/DELETE to return 405.

## Fix
Add a targeted nginx regex location for:
`/api/userdata/workflows/<file>`

and proxy it upstream as:
`/api/userdata/workflows%2F<file>`

`/ws` and the default proxy path are unchanged.

## Validation
- `modal run server/app.py::prepare`
  - `DONE model link sync: linked=11 missing=0`
- Health checks:
  - `/system_stats` 200
  - `/api/system_stats` 200
  - `/queue` 200
  - `/history` 200
- Workflow RW smoke:
  - `POST /api/userdata/workflows%2Fcodex-nginx-rw-smoke-1778728798669.json` -> 200
  - `GET` -> 200
  - `DELETE` -> 204
- Browser interrupt test:
  - `/prompt` -> 200
  - `/api/interrupt` -> 200, about 357ms
  - history: `status_str=error`, `completed=false`, includes `execution_interrupted`
- API workflow test:
  - workflow: `workflows/(API) newbie-official-260514-interrupt-test.json`
  - prompt_id: `aee40fdc-e841-436e-ab0b-ec67ea21917c`
  - `/prompt` -> 200
  - `/api/interrupt` -> 200
  - final history includes `execution_interrupted` at node `59` `CLIPTextEncode`
- Static checks:
  - `python -m py_compile server/app.py server/ui.py serve.py`
  - `git diff --check`

## Risk
Low code-change risk, but nginx routing is sensitive. Keep this PR as a documented checkpoint before merging.