### PR TITLE
Allow changing GPU type using ENV variable

### DIFF
--- a/comfyui.py
+++ b/comfyui.py
@@ -13,6 +13,7 @@ root_dir = Path(__file__).parent
 
 COMFY_MODELS_ROOT = Path("/root/comfy/ComfyUI/models")
 
+GPU_TYPE = os.getenv("MODAL_GPU", "L4")
 
 def resolve_model_dir(model_dir: str) -> Path:
     """Resolve model_dir: absolute paths are used as-is, relative paths are
@@ -172,7 +173,7 @@ app = modal.App(name="modal-comfyui", image=image)
 
 @app.cls(
     max_containers=1,
-    gpu="L4",
+    gpu=GPU_TYPE,
     volumes={"/cache": vol},
     scaledown_window=60,  # idle 1 minutes to shutdown
     enable_memory_snapshot=True,


### PR DESCRIPTION
This will be more convenient when testing out different GPU without the need to change the source code.

So we can deployed it with: 
```
MODAL_GPU=RTX-PRO-6000 modal deploy comfyui.py
```
which only took less than 7 seconds to redeployed with a different GPU.
<img width="1080" height="2436" alt="IMG_20260518_071719_305" src="https://github.com/user-attachments/assets/3818e03a-4d72-4503-8f29-4495574515e0" />

