### PR TITLE
Fix ERROR 400 Bad Request issue when downloading from CivitAI.

### DIFF
--- a/comfyui.py
+++ b/comfyui.py
@@ -71,20 +71,19 @@ def download_external_model(url: str, filename: str, model_dir: str):
     if not cached_path.exists():
         print(f"Downloading {filename} from {url}...")
         # Use CivitAI token when available
-        token_hdr = ""
+        uri = url
         if url.startswith("https://civitai.com/") or url.startswith("https://civitai.red/"):
             token = os.environ.get("CIVITAI_TOKEN", "")
             if token:
-                token_hdr = f"Authorization: Bearer {token}"
+                uri = f"{url}{'&' if '?' in url else '?'}token={token}"
             
         try:
             _ = subprocess.run(
                 [
                     "axel",
-                    "-H", token_hdr,
                     "-n", "16",
                     "-o", cached_path,
-                    url,
+                    uri,
                 ],
                 check=True,
                 stdout=subprocess.DEVNULL,

--- a/comfyui.py
+++ b/comfyui.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import modal
 
@@ -70,20 +71,25 @@ def download_external_model(url: str, filename: str, model_dir: str):
     cached_path = Path(cache_dir) / filename
     if not cached_path.exists():
         print(f"Downloading {filename} from {url}...")
-        # Use CivitAI token when available
-        uri = url
-        if url.startswith("https://civitai.com/") or url.startswith("https://civitai.red/"):
+        # Pass the CivitAI token as a query param rather than an Authorization
+        # header: axel re-sends -H headers to the redirect target (an R2
+        # presigned URL), which rejects them with 400.
+        download_url = url
+        if url.startswith(("https://civitai.com/", "https://civitai.red/")):
             token = os.environ.get("CIVITAI_TOKEN", "")
             if token:
-                uri = f"{url}{'&' if '?' in url else '?'}token={token}"
-            
+                parts = urlsplit(url)
+                query = dict(parse_qsl(parts.query))
+                query.setdefault("token", token)
+                download_url = urlunsplit(parts._replace(query=urlencode(query)))
+
         try:
             _ = subprocess.run(
                 [
                     "axel",
                     "-n", "16",
                     "-o", cached_path,
-                    uri,
+                    download_url,
                 ],
                 check=True,
                 stdout=subprocess.DEVNULL,


### PR DESCRIPTION
Passing CIVITAI_TOKEN through query parameter seems to be better (fail-proof) than through Authorization header.